### PR TITLE
Disable submit button for 30 seconds after click

### DIFF
--- a/index.html
+++ b/index.html
@@ -778,12 +778,12 @@
               window.setTimeout(function enableSubmit() {
                 $submit.prop('disabled', false).val(
                   'Submission failed. Click to try again.');
-              }, 60 * 1000);
+              }, 30 * 1000);
               // Just to be nice, let the user know stuff's still going on
               // halfway through that waiting period.
               window.setTimeout(function reassureUser() {
                 $submit.val('Still trying to submit...');
-              }, 30 * 1000);
+              }, 10 * 1000);
             });
           })(this, window.jQuery);
         </script>

--- a/index.html
+++ b/index.html
@@ -764,5 +764,28 @@
 <!-- Include all compiled plugins (below), or include individual files as needed -->
 	 <script src=
 	"http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+         <!-- Disable submit button for 60 seconds after click -->
+        <script>
+          (function(window, $) {
+            var $form = $('#ss-form'),
+              $submit = $('#ss-submit');
+
+            $form.on('submit', function disableSubmit(event) {
+              // Disable the button and change its message so the user knows
+              // what's up.
+              $submit.prop('disabled', true).val('Submitting...');
+              // Re-enable the button in 60 seconds, assuming we're still here.
+              window.setTimeout(function enableSubmit() {
+                $submit.prop('disabled', false).val(
+                  'Submission failed. Click to try again.');
+              }, 60 * 1000);
+              // Just to be nice, let the user know stuff's still going on
+              // halfway through that waiting period.
+              window.setTimeout(function reassureUser() {
+                $submit.val('Still trying to submit...');
+              }, 30 * 1000);
+            });
+          })(this, window.jQuery);
+        </script>
 </body>
 </html>


### PR DESCRIPTION
This disables the submit button once it's clicked. It shows a message 10 seconds afterward saying it's still working on submitting the form, and it re-enables the button 30 seconds after the initial click with a message saying to try again. [See this video for an earlier 30-second/60-second example.](https://www.dropbox.com/s/kvz4fdusgs8abg8/disable.mov?dl=0)
