### PR TITLE
Use protocol-agnostic URLs for script and link tags

### DIFF
--- a/sharing.html
+++ b/sharing.html
@@ -10,13 +10,13 @@
 	<!-- Bootstrap -->
 	<!-- Latest compiled and minified CSS -->
 	<link href=
-	"http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" rel=
+	"//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" rel=
 	"stylesheet"><!-- Optional theme -->
 	<link href=
-	"http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap-theme.min.css"
+	"//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap-theme.min.css"
 	rel="stylesheet">
 	<link rel="stylesheet" href="//code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css">
-	<link href='http://fonts.googleapis.com/css?family=Roboto' rel='stylesheet' type='text/css'>
+	<link href='//fonts.googleapis.com/css?family=Roboto' rel='stylesheet' type='text/css'>
 	<!-- Third theme, via Google: https://ssl.gstatic.com/docs/script/css/add-ons1.css -->
 	<link href="css/form.css" rel="stylesheet">
 	<link href="assets/favicon.png" rel="shortcut icon" type="image/png">
@@ -132,9 +132,9 @@
 		</div>
 	</div>
 	<!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 	<!-- Include all compiled plugins (below), or include individual files as needed -->
-	<script src="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+	<script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 	<script src="//code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
 	<script src="js/jquery.zeroclipboard.min.js"></script>
 	<!-- twitter widget loading script -->
@@ -209,7 +209,7 @@
 				// recreate the tweet button
 				twttr.ready(function(){
 					twttr.widgets.createShareButton(
-						'http://juliajrh.github.io/journosalarysharer/',
+						'https://juliajrh.github.io/journosalarysharer/',
 						document.getElementById('twitter-button'),
 						{
 							text: shareText,


### PR DESCRIPTION
## Changes

Replaces `http://` with `//` in URLs in `link` and `style` tags, so that the Javascript on the sharing page will load. 
## Why

If the site is visited over HTTPS, the sharing page doesn't work because of content errors. :disappointed: 

As seen on https://juliajrh.github.io/journosalarysharer/sharing :

<img width="744" alt="screen shot 2015-08-11 at 7 01 14 pm" src="https://cloud.githubusercontent.com/assets/1754187/9212946/61cb0406-405b-11e5-85d6-a6248fb7bd0b.png">
